### PR TITLE
Solidity: naming consistency fixes

### DIFF
--- a/eth-custodian/contracts/EthCustodian.sol
+++ b/eth-custodian/contracts/EthCustodian.sol
@@ -37,14 +37,14 @@ contract EthCustodian is ProofKeeper, AdminControlled {
     /// EthCustodian is linked to the EVM on NEAR side.
     /// It also links to the prover that it uses to withdraw the tokens.
     constructor(
-        bytes memory nearEvm,
-        INearProver prover,
-        uint64 minBlockAcceptanceHeight,
+        bytes memory _nearEvm,
+        INearProver _prover,
+        uint64 _minBlockAcceptanceHeight,
         address _admin,
-        uint pausedFlags
+        uint _pausedFlags
     )
-        AdminControlled(_admin, pausedFlags)
-        ProofKeeper(nearEvm, prover, minBlockAcceptanceHeight)
+        AdminControlled(_admin, _pausedFlags)
+        ProofKeeper(_nearEvm, _prover, _minBlockAcceptanceHeight)
         public
     {
     }
@@ -67,7 +67,7 @@ contract EthCustodian is ProofKeeper, AdminControlled {
 
         string memory protocolMessage = string(
             abi.encodePacked(
-                string(nearProofProducerAccount_),
+                string(nearProofProducerAccount),
                 MESSAGE_SEPARATOR, ethRecipientOnNear
             )
         );

--- a/eth-custodian/contracts/ProofKeeper.sol
+++ b/eth-custodian/contracts/ProofKeeper.sol
@@ -9,35 +9,35 @@ contract ProofKeeper {
     using Borsh for Borsh.Data;
     using ProofDecoder for Borsh.Data;
 
-    INearProver public prover_;
-    bytes public nearProofProducerAccount_;
+    INearProver public prover;
+    bytes public nearProofProducerAccount;
 
     /// Proofs from blocks that are below the acceptance height will be rejected.
-    // If `minBlockAcceptanceHeight_` value is zero - proofs from block with any height are accepted.
-    uint64 public minBlockAcceptanceHeight_;
+    // If `minBlockAcceptanceHeight` value is zero - proofs from block with any height are accepted.
+    uint64 public minBlockAcceptanceHeight;
 
     // OutcomeReciptId -> Used
-    mapping(bytes32 => bool) public usedEvents_;
+    mapping(bytes32 => bool) public usedEvents;
 
     constructor(
-        bytes memory nearProofProducerAccount,
-        INearProver prover,
-        uint64 minBlockAcceptanceHeight
-    ) 
-        public 
+        bytes memory _nearProofProducerAccount,
+        INearProver _prover,
+        uint64 _minBlockAcceptanceHeight
+    )
+        public
     {
         require(
-            nearProofProducerAccount.length > 0,
+            _nearProofProducerAccount.length > 0,
             'Invalid Near ProofProducer address'
         );
         require(
-            address(prover) != address(0),
+            address(_prover) != address(0),
             'Invalid Near prover address'
         );
 
-        nearProofProducerAccount_ = nearProofProducerAccount;
-        prover_ = prover;
-        minBlockAcceptanceHeight_ = minBlockAcceptanceHeight;
+        nearProofProducerAccount = _nearProofProducerAccount;
+        prover = _prover;
+        minBlockAcceptanceHeight = _minBlockAcceptanceHeight;
     }
 
     /// Parses the provided proof and consumes it if it's not already used.
@@ -50,11 +50,11 @@ contract ProofKeeper {
         returns(ProofDecoder.ExecutionStatus memory result)
     {
         require(
-            proofBlockHeight >= minBlockAcceptanceHeight_,
+            proofBlockHeight >= minBlockAcceptanceHeight,
             'Proof is from an ancient block'
         );
         require(
-            prover_.proveOutcome(proofData,proofBlockHeight),
+            prover.proveOutcome(proofData,proofBlockHeight),
             'Proof should be valid'
         );
 
@@ -71,14 +71,14 @@ contract ProofKeeper {
         bytes32 receiptId = fullOutcomeProof.outcome_proof.outcome_with_id.outcome.receipt_ids[0];
 
         require(
-            !usedEvents_[receiptId],
+            !usedEvents[receiptId],
             'The burn event cannot be reused'
         );
-        usedEvents_[receiptId] = true;
+        usedEvents[receiptId] = true;
 
         require(
             keccak256(fullOutcomeProof.outcome_proof.outcome_with_id.outcome.executor_id) == 
-            keccak256(nearProofProducerAccount_),
+            keccak256(nearProofProducerAccount),
             'Can only withdraw coins from the linked proof producer on Near blockchain'
         );
 

--- a/eth-custodian/scripts/eth_get_prover_address.js
+++ b/eth-custodian/scripts/eth_get_prover_address.js
@@ -1,7 +1,7 @@
 const hre = require('hardhat');
 
 const erc20ConnectorAbi = require('./json/erc20-connector.json');
-const erc20ConnectorAddress = '0xc115851ca60aed2ccc6ee3d5343f590834e4a3ab';
+const erc20ConnectorAddress = '0xa5289b6d5dcc13e48f2cc6382256e51589849f86';
 
 
 // Gets the prover address from the deployed ERC20Connector with the provided address

--- a/eth-custodian/scripts/eth_get_prover_address.js
+++ b/eth-custodian/scripts/eth_get_prover_address.js
@@ -1,7 +1,7 @@
 const hre = require('hardhat');
 
 const erc20ConnectorAbi = require('./json/erc20-connector.json');
-const erc20ConnectorAddress = '0xa5289b6d5dcc13e48f2cc6382256e51589849f86';
+const erc20ConnectorAddress = '0xc115851ca60aed2ccc6ee3d5343f590834e4a3ab';
 
 
 // Gets the prover address from the deployed ERC20Connector with the provided address
@@ -12,7 +12,7 @@ async function main() {
 
     // Connect to Erc20Connector to get the prover address
     const erc20Connector = new hre.ethers.Contract(erc20ConnectorAddress, erc20ConnectorAbi, deployerAccount);
-    const proverAddress = await erc20Connector.prover_();
+    const proverAddress = await erc20Connector.prover();
 
     console.log(`Prover address: ${proverAddress}`);
 }

--- a/eth-custodian/scripts/json/erc20-connector.json
+++ b/eth-custodian/scripts/json/erc20-connector.json
@@ -85,7 +85,7 @@
   },
   {
     "inputs": [],
-    "name": "admin_",
+    "name": "admin",
     "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "stateMutability": "view",
     "type": "function"
@@ -113,14 +113,14 @@
   },
   {
     "inputs": [],
-    "name": "nearTokenFactory_",
+    "name": "nearTokenFactory",
     "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
-    "name": "prover_",
+    "name": "prover",
     "outputs": [
       { "internalType": "contract INearProver", "name": "", "type": "address" }
     ],
@@ -139,7 +139,7 @@
   },
   {
     "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "name": "usedEvents_",
+    "name": "usedEvents",
     "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
     "stateMutability": "view",
     "type": "function"


### PR DESCRIPTION
The `rainbow-bridge` contracts don't use trailing underscores for the public variables' names, so we need to keep consistency across all connectors.