### PR TITLE
EthCustodian: `withdraw` method improvements. Update OZ version.

### DIFF
--- a/eth-custodian/contracts/EthCustodian.sol
+++ b/eth-custodian/contracts/EthCustodian.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8;
 
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 import 'rainbow-bridge-sol/nearbridge/contracts/AdminControlled.sol';
 import 'rainbow-bridge-sol/nearbridge/contracts/Borsh.sol';
@@ -122,7 +122,7 @@ contract EthCustodian is ProofKeeper, AdminControlled, ReentrancyGuard {
             result.ethCustodian == address(this),
             'Can only withdraw coins that were expected for the current contract'
         );
-        payable(result.recipient).call.value(result.amount)("");
+        payable(result.recipient).call{value: result.amount}("");
         emit Withdrawn(
             result.recipient,
             result.amount

--- a/eth-custodian/package.json
+++ b/eth-custodian/package.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "dependencies": {
         "@nomiclabs/hardhat-solhint": "^2.0.0",
-        "@openzeppelin/contracts": "^3.4.0",
+        "@openzeppelin/contracts": "^4.5.0",
         "bs58": "^4.0.1",
         "dotenv": "^8.2.0",
         "eth-object": "https://github.com/near/eth-object",

--- a/eth-custodian/yarn.lock
+++ b/eth-custodian/yarn.lock
@@ -759,10 +759,10 @@
     find-up "^4.1.0"
     fs-extra "^8.1.0"
 
-"@openzeppelin/contracts@^3.4.0":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1.tgz#03c891fec7f93be0ae44ed74e57a122a38732ce7"
-  integrity sha512-cUriqMauq1ylzP2TxePNdPqkwI7Le3Annh4K9rrpvKfSBB/bdW+Iu1ihBaTIABTAAJ85LmKL5SSPPL9ry8d1gQ==
+"@openzeppelin/contracts@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
+  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
 
 "@openzeppelin/test-helpers@^0.5.10":
   version "0.5.10"


### PR DESCRIPTION
* EthCustodian: `withdraw()` method - use `call()` instead of  `transfer()`.
* EthCustodian: upgrade OpenZeppelin contracts dependency to 4.5

It's required to change it for the future as `transfer()` gas provided might change. Reentrancy is being handled because the proof is consumed at the very beginning of the method.